### PR TITLE
Update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   jekyll-haml (~> 0.1.5)
 
 BUNDLED WITH
-   1.16.0
+   2.0.2


### PR DESCRIPTION
bundler のバージョンが古すぎるのでメンテナンスに支障が出るためバージョンを上げます。

```
% bundle
Traceback (most recent call last):    
        2: from /usr/local/opt/ruby/bin/bundle:23:in `<main>'                                                                                               
        1: from /usr/local/Cellar/ruby/2.6.3/lib/ruby/2.6.0/rubygems.rb:302:in `activate_bin_path'                                                          
/usr/local/Cellar/ruby/2.6.3/lib/ruby/2.6.0/rubygems.rb:283:in `find_spec_for_exe': Could not find 'bundler' (1.16.0) required by your /Users/itochan/git/sf
c-arch.github.io/Gemfile.lock. (Gem::GemNotFoundException)                    
To update to the latest version installed on your system, run `bundle update --bundler`.                                                                    
To install the missing version, run `gem install bundler:1.16.0`
```

## 変更内容
- `bundle update --bundler` を実行した差分をコミット